### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,17 +13,17 @@ ClosedCube_HDC1010	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ##################################################################
 
-begin KEYWORD2
-readManufacturerID KEYWORD2
-readDeviceID KEYWORD2
+begin	KEYWORD2
+readManufacturerID	KEYWORD2
+readDeviceID	KEYWORD2
 
-readRegister KEYWORD2
-writeRegister KEYWORD2
+readRegister	KEYWORD2
+writeRegister	KEYWORD2
 
-heatUp KEYWORD2
+heatUp	KEYWORD2
 
-readTemperature KEYWORD2
-readHumidity KEYWORD2
+readTemperature	KEYWORD2
+readHumidity	KEYWORD2
 
-readT KEYWORD2
-readH KEYWORD2
+readT	KEYWORD2
+readH	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords